### PR TITLE
lint,puppet strict mode and librarian-puppet

### DIFF
--- a/manifests/auth.pp
+++ b/manifests/auth.pp
@@ -37,7 +37,7 @@ class dovecot::auth (
 
   if $passdb =~ Array[Hash] {
     range(0,size($passdb)-1).each |$k| {
-      $order = 50+$k
+      $order = sprintf('%d', 50+$k)
       $opts = $passdb[$k]
 
       case $opts['driver'] {
@@ -74,7 +74,7 @@ class dovecot::auth (
   } else {
     $passdb_keys = keys($passdb)
     range(0,size($passdb_keys)-1).each |$k| {
-      $order = 50+$k
+      $order = sprintf('%d', 50+$k)
       $opts = $passdb[$passdb_keys[$k]]
 
       case $opts['driver'] {
@@ -112,7 +112,7 @@ class dovecot::auth (
 
   if $userdb =~ Array[Hash] {
     range(0,size($userdb)-1).each |$k| {
-      $order = 70+$k
+      $order = sprintf('%d', 70+$k)
       $opts = $userdb[$k]
 
       case $opts['driver'] {
@@ -141,7 +141,7 @@ class dovecot::auth (
   } else {
     $userdb_keys = keys($userdb)
     range(0,size($userdb_keys)-1).each |$k| {
-      $order = 70+$k
+      $order = sprintf('%d', 70+$k)
       $opts = $userdb[$userdb_keys[$k]]
 
       case $opts['driver'] {

--- a/manifests/auth.pp
+++ b/manifests/auth.pp
@@ -48,19 +48,25 @@ class dovecot::auth (
           ]
         }
         # TODO: Programar un require del passwd-file, pero como puede
-        # haber más de un argumento...
-        'passwd-file': { }
-        'pam': { }
+        # haber mas de un argumento...
+        'passwd-file': {
+          $require = undef
+        }
+        'pam': {
+          $require = undef
+        }
         'sql': {
           $require = Dovecot::Auth::Sqlfile[$opts['args']]
         }
-        'static': { }
+        'static': {
+          $require = undef
+        }
         default: {
           fail("Driver ${opts['driver']} not supported")
         }
       }
-      dovecot::auth::passdb {"${order}":
-        order   => "${order}",
+      dovecot::auth::passdb {$order:
+        order   => $order,
         require => $require,
         *       => $opts,
       }
@@ -79,19 +85,25 @@ class dovecot::auth (
           ]
         }
         # TODO: Programar un require del passwd-file, pero como puede
-        # haber más de un argumento...
-        'passwd-file': { }
-        'pam': { }
+        # haber mas de un argumento...
+        'passwd-file': {
+          $require = undef
+        }
+        'pam': {
+          $require = undef
+        }
         'sql': {
           $require = Dovecot::Auth::Sqlfile[$opts['args']]
         }
-        'static': { }
+        'static': {
+          $require = undef
+        }
         default: {
           fail("Driver ${opts['driver']} not supported")
         }
       }
-      dovecot::auth::passdb {"${order}":
-        order   => "${order}",
+      dovecot::auth::passdb {$order:
+        order   => $order,
         require => $require,
         *       => $opts,
       }
@@ -104,19 +116,24 @@ class dovecot::auth (
       $opts = $userdb[$k]
 
       case $opts['driver'] {
+        'passwd-file': {
+          $require = undef
+        }
         'ldap': {
           $require = [
             Class['dovecot::ldap'],
             Dovecot::Auth::Ldapfile[$opts['args']],
           ]
         }
-        /static|prefetch/: { }
+        /static|prefetch/: {
+          $require = undef
+        }
         default: {
           fail("Driver ${opts['driver']} not supported")
         }
       }
-      dovecot::auth::userdb {"${order}":
-        order   => "${order}",
+      dovecot::auth::userdb {$order:
+        order   => $order,
         require => $require,
         *       => $opts,
       }
@@ -128,20 +145,24 @@ class dovecot::auth (
       $opts = $userdb[$userdb_keys[$k]]
 
       case $opts['driver'] {
-        'passwd-file': { }
+        'passwd-file': {
+          $require = undef
+        }
         'ldap': {
           $require = [
             Class['dovecot::ldap'],
             Dovecot::Auth::Ldapfile[$opts['args']],
           ]
         }
-        /static|prefetch/: { }
+        /static|prefetch/: {
+          $require = undef
+        }
         default: {
           fail("Driver ${opts['driver']} not supported")
         }
       }
-      dovecot::auth::userdb {"${order}":
-        order   => "${order}",
+      dovecot::auth::userdb {$order:
+        order   => $order,
         require => $require,
         *       => $opts,
       }
@@ -150,7 +171,7 @@ class dovecot::auth (
 
   dovecot::config::dovecotcfmulti {'Remove default system auth':
     config_file => 'conf.d/10-auth.conf',
-    onlyif      => "values include include auth-system.conf.ext",
+    onlyif      => 'values include include auth-system.conf.ext',
     changes     => [ "rm include[ . = \"auth-system.conf.ext\" ]" ],
   }
 

--- a/manifests/namespace.pp
+++ b/manifests/namespace.pp
@@ -1,7 +1,7 @@
 # 15-mailboxes.conf
 # See README.md for usage
 #
-# Augeas no me deja poner las opciones \Drafts, etc, así que lo defino
+# Augeas no me deja poner las opciones \Drafts, etc, asi que lo defino
 # con un template y tengo que hacerlo con un template
 define dovecot::namespace (
   Enum['present','absent'] $ensure                  = present,

--- a/metadata.json
+++ b/metadata.json
@@ -22,9 +22,6 @@
       "version_requirement": ">=4.0.0"
     }
   ],
-  "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":"4.3.2"}
-  ],
   "description": "Dovecot module. It is tested in Ubuntu, but it should work too on Debian. It is not tested on redhat based systems, but it could work whithout major changes. This module was started from a form from https://github.com/mjhas/dovecot.git.",
   "data_provider": "hiera"
 }


### PR DESCRIPTION
Hi,

I tried to install the dovecote module via librarian-puppet, and a automated build/lint process on a puppet server running in strict mode, these where the changes i needed to apply to use the module.

* to install the module via librarian-puppet, i removed the duplicate stdlib referance

* define the $require var, to make the catalog compile

* to fix the lint errors: I needed to make these changes:
- i removed 2 non 'ascii' characters, 
- cast order as string, so the additional {'s where no longer needed 

Regards,

Niels Jansen