### PR TITLE
Support for Redhat-family packaging

### DIFF
--- a/data/os/redhat.yaml
+++ b/data/os/redhat.yaml
@@ -1,3 +1,6 @@
 ---
 dovecot::packages:
   - 'dovecot'
+
+dovecot::managesieved::packages:
+  - 'dovecot-pigeonhole'

--- a/manifests/imap/install.pp
+++ b/manifests/imap/install.pp
@@ -1,8 +1,15 @@
 #
 class dovecot::imap::install inherits dovecot::imap {
-  if $dovecot::package_manage {
-    package {$dovecot::imap::package_name:
-      ensure => $dovecot::package_ensure,
+  case $facts['os']['family'] {
+    'Debian': {
+      if $dovecot::package_manage {
+        package {$dovecot::imap::package_name:
+          ensure => $dovecot::package_ensure,
+        }
+      }
+    }
+    'RedHat': {
+      # Do nothing since this is included in the core yum dovecot package
     }
   }
 }

--- a/manifests/ldap/install.pp
+++ b/manifests/ldap/install.pp
@@ -1,8 +1,15 @@
 #
 class dovecot::ldap::install inherits dovecot::ldap {
-  if $dovecot::package_manage {
-    package {$dovecot::ldap::package_name:
-      ensure => $dovecot::package_ensure,
+  case $facts['os']['family'] {
+    'Debian': {
+      if $dovecot::package_manage {
+        package {$dovecot::ldap::package_name:
+          ensure => $dovecot::package_ensure,
+        }
+      }
+    }
+    'RedHat': {
+      # Do nothing since this is included in the core yum dovecot package
     }
   }
 }

--- a/manifests/lmtp/install.pp
+++ b/manifests/lmtp/install.pp
@@ -1,8 +1,15 @@
 #
 class dovecot::lmtp::install inherits dovecot::lmtp {
-  if $dovecot::package_manage {
-    package {$dovecot::lmtp::package_name:
-      ensure => $dovecot::package_ensure,
+  case $facts['os']['family'] {
+    'Debian': {
+      if $dovecot::package_manage {
+        package {$dovecot::lmtp::package_name:
+          ensure => $dovecot::package_ensure,
+        }
+      }
+    }
+    'RedHat': {
+      # Do nothing since this is included in the core yum dovecot package
     }
   }
 }

--- a/manifests/pop3/install.pp
+++ b/manifests/pop3/install.pp
@@ -1,8 +1,15 @@
 #
 class dovecot::pop3::install inherits dovecot::pop3 {
-  if $dovecot::package_manage {
-    package {$dovecot::pop3::package_name:
-      ensure => $dovecot::package_ensure,
+  case $facts['os']['family'] {
+    'Debian': {
+      if $dovecot::package_manage {
+        package {$dovecot::pop3::package_name:
+          ensure => $dovecot::package_ensure,
+        }
+      }
+    }
+    'RedHat': {
+      # Do nothing since this is included in the core yum dovecot package
     }
   }
 }

--- a/manifests/sqlite/install.pp
+++ b/manifests/sqlite/install.pp
@@ -1,8 +1,15 @@
 #
 class dovecot::sqlite::install inherits dovecot::sqlite {
-  if $dovecot::package_manage {
-    package {$dovecot::sqlite::package_name:
-      ensure => $dovecot::package_ensure,
+  case $facts['os']['family'] {
+    'Debian': {
+      if $dovecot::package_manage {
+        package {$dovecot::sqlite::package_name:
+          ensure => $dovecot::package_ensure,
+        }
+      }
+    }
+    'RedHat': {
+      # Do nothing since this is included in the core yum dovecot package
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -14,6 +14,11 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
       ]
+    },
+    {
+      "operatingsystem": "Redhat",
+      "operatingsystemrelease": [
+      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
Add in support for RH systems, which don't have too many of the same packages as Debian-based. Basically I had to disable the package {} resource usage in those classes when the OS family was RH. 

In addition, with Puppet 5.0, your use of hiera v4 files means that the data/os directory is not being correctly read since I had to explicitly list the package in the only.  Perhaps a case change is needed in the file to match exactly the family name (ie RedHat.yaml rather than redhat.yaml)

Finally, can't test the changes since you're using the very old rspec-system. This was end of lifed 4 years ago. New code uses beaker-rspec. 