### PR TITLE
Add "passwd" as a valid driver for auth

### DIFF
--- a/manifests/auth.pp
+++ b/manifests/auth.pp
@@ -116,6 +116,9 @@ class dovecot::auth (
       $opts = $userdb[$k]
 
       case $opts['driver'] {
+        'passwd': {
+          $require = undef
+        }
         'passwd-file': {
           $require = undef
         }


### PR DESCRIPTION
"passwd" tells Dovecot to use the _system_ password files via PAM or
other authentication mechanism.

Note that this is not the same as "passwd_file", which is used for
looking up users in an alternative file that uses the same format as the
system /etc/passwd files.